### PR TITLE
fix enable android neon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,9 @@ set(CMAKE_C_STANDARD 11)
 
 # ARM NEON
 if(ENABLE_NEON)
-  if(ARM OR AARCH64 OR IOS OR (CMAKE_C_COMPILER MATCHES ".*arm-linux-gnueabi-gcc$"))
+  if(((IOS_ARCH MATCHES "armv7") OR (IOS_ARCH MATCHES "arm64")) OR
+    ((CMAKE_ANDROID_ARCH_ABI MATCHES armeabi-v7a)) OR
+    (CMAKE_C_COMPILER MATCHES ".*arm-linux-gnueabi-gcc$"))
     set(WITH_NEON ON)
   endif()
 endif()

--- a/scripts/speck/build_android.sh
+++ b/scripts/speck/build_android.sh
@@ -18,7 +18,7 @@ android_ndk_build() {
     /bin/rm -rf build
     /bin/mkdir build
     pushd build > /dev/null
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=${SYSTEM_VERSION} -DCMAKE_ANDROID_ARCH_ABI=${ARCH} -DCMAKE_ANDROID_NDK=${NDK_ROOT} $OTHER_FLAG ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_SYSTEM_VERSION=${SYSTEM_VERSION} -DCMAKE_ANDROID_ARCH_ABI=${ARCH} -DCMAKE_ANDROID_NDK=${NDK_ROOT} $OTHER_FLAG ..
     cmake --build .
     popd > /dev/null
 


### PR DESCRIPTION
enable arm neon on below archtectures

- ios
    - armv7
    - armv7s
    - arm64
- android
    - armeabi-v7a
- linux
    - arm(corss compile)